### PR TITLE
Simplify outpath handling

### DIFF
--- a/blender/blender_merge.py
+++ b/blender/blender_merge.py
@@ -1,17 +1,17 @@
 import bpy
 import os
+import pathlib
 import sys
 
 # Example call:
-# blender.exe --background HDR_Merge.blend --factory-startup --python blender_merge.py -- 3456x5184 "C:/foo/bar/Merged" ND8_ND400 0 imgpath1___12 imgpath2___9 imgpath3___6 imgpath4___3 imgpath5___0
+# blender.exe --background HDR_Merge.blend --factory-startup --python blender_merge.py -- 3456x5184 "C:/foo/bar/Merged/exr/merged_000.exr" ND8_ND400 imgpath1___12 imgpath2___9 imgpath3___6 imgpath4___3 imgpath5___0
 
 argv = sys.argv
 argv = argv[argv.index("--")+1:]  # get all args after "--"
 RESOLUTION = [int(d) for d in argv[0].split('x')]  # list where first position is X-res, second position is Y-res
-OUT_FOLDER = argv[1]
+EXR_OUTFILE = argv[1]
 FILTERS = argv[2]
-INDEX = int(argv[3])  # Current set number
-IMAGES = sorted([i.split("___") for i in argv[4:]], key=lambda x: float(x[1]))
+IMAGES = sorted([i.split("___") for i in argv[3:]], key=lambda x: float(x[1]))
 
 nodes = []
 groups = [None]
@@ -49,14 +49,16 @@ if "ND8" in FILTERS:
 if "ND400" in FILTERS:
     filter_fix('ND400', nt, nodes)
 
-if not os.path.exists(OUT_FOLDER):
-    os.makedirs(OUT_FOLDER)
+exr_fpath = pathlib.Path(EXR_OUTFILE)
+
+if not exr_fpath.parent.exists():
+    exr_fpath.parent.mkdir(parents=True, exist_ok=True)
 
 rset = bpy.context.scene.render
-rset.filepath = os.path.join(OUT_FOLDER, "merged_" + str(INDEX).zfill(3) + ".exr")
+rset.filepath = str(exr_fpath)
 rset.resolution_x = RESOLUTION[0]
 rset.resolution_y = RESOLUTION[1]
 
 bpy.ops.render.render(write_still=True)  # Render!
 
-bpy.ops.wm.save_as_mainfile(filepath=os.path.join(OUT_FOLDER, "bracket_sample.blend"))
+bpy.ops.wm.save_as_mainfile(filepath=str(exr_fpath.with_name("bracket_sample.blend")))

--- a/hdr_brackets.py
+++ b/hdr_brackets.py
@@ -201,10 +201,10 @@ class HDRBrackets(Frame):
                  exifs, out_folder: pathlib.Path,
                  filter_used, i, img_list, folder: pathlib.Path, luminance_cli_exe):
 
-        jpg_folder = out_folder.parent / "jpg"
+        jpg_folder = out_folder / "jpg"
         jpg_folder.mkdir(parents=True, exist_ok=True)
 
-        exr_path = out_folder / ('merged_%03d.exr' % i)
+        exr_path = out_folder / ('exr/merged_%03d.exr' % i)
         jpg_path = jpg_folder / exr_path.with_suffix('.jpg').name
 
         if exr_path.exists():
@@ -262,7 +262,7 @@ class HDRBrackets(Frame):
             merge_blend = SCRIPT_DIR / "blender" / "HDR_Merge.blend"
             merge_py = SCRIPT_DIR / "blender" / "blender_merge.py"
 
-            out_folder = folder / "Merged/exr"
+            out_folder = folder / "Merged"
             glob = self.extension.get()
             if '*' not in glob:
                 glob = '*%s' % glob

--- a/hdr_brackets.py
+++ b/hdr_brackets.py
@@ -200,6 +200,17 @@ class HDRBrackets(Frame):
                  merge_blend: pathlib.Path, merge_py: pathlib.Path,
                  exifs, out_folder: pathlib.Path,
                  filter_used, i, img_list, folder: pathlib.Path, luminance_cli_exe):
+
+        jpg_folder = out_folder.parent / "jpg"
+        jpg_folder.mkdir(parents=True, exist_ok=True)
+
+        exr_path = out_folder / ('merged_%03d.exr' % i)
+        jpg_path = jpg_folder / exr_path.with_suffix('.jpg').name
+
+        if exr_path.exists():
+            print ("Skipping set %d, %s exists" % (i, exr_path))
+            return
+
         print ("Merging", i)
         cmd = [
             blender_exe,
@@ -210,18 +221,11 @@ class HDRBrackets(Frame):
             merge_py.as_posix(),
             '--',
             exifs[0]['resolution'],
-            out_folder.as_posix(),
+            exr_path.as_posix(),
             filter_used,
-            str(i)
         ]
         cmd += img_list
         subprocess.check_call(cmd)
-
-        jpg_folder = out_folder.parent / "jpg"
-        jpg_folder.mkdir(parents=True, exist_ok=True)
-
-        exr_path = out_folder / ('merged_%03d.exr' % i)
-        jpg_path = jpg_folder / exr_path.with_suffix('.jpg').name
 
         cmd = [
             luminance_cli_exe,
@@ -287,11 +291,6 @@ class HDRBrackets(Frame):
                 img_list = []
                 for ii,img in enumerate(s):
                     img_list.append(img.as_posix()+'___'+str(evs[ii]))
-
-                out_fpath = out_folder / ("merged_%03d.exr" % i)
-                if out_fpath.exists():
-                    print ("Skipping set %d, %s exists" % (i, out_fpath))
-                    continue
 
                 # self.do_merge (blender_exe, merge_blend, merge_py, exifs, out_folder, filter_used, i, img_list, folder, luminance_cli_exe)
                 t = executor.submit(self.do_merge, blender_exe, merge_blend, merge_py, exifs, out_folder, filter_used, i, img_list, folder, luminance_cli_exe)

--- a/hdr_brackets.py
+++ b/hdr_brackets.py
@@ -201,10 +201,13 @@ class HDRBrackets(Frame):
                  exifs, out_folder: pathlib.Path,
                  filter_used, i, img_list, folder: pathlib.Path, luminance_cli_exe):
 
-        jpg_folder = out_folder / "jpg"
+        exr_folder = out_folder / 'exr'
+        jpg_folder = out_folder / 'jpg'
+
+        exr_folder.mkdir(parents=True, exist_ok=True)
         jpg_folder.mkdir(parents=True, exist_ok=True)
 
-        exr_path = out_folder / ('exr/merged_%03d.exr' % i)
+        exr_path = exr_folder / ('merged_%03d.exr' % i)
         jpg_path = jpg_folder / exr_path.with_suffix('.jpg').name
 
         if exr_path.exists():


### PR DESCRIPTION
This PR has two commits:

## First

The `out_folder / ("merged_%03d.exr" % i)` construct was duplicated twice (it appeared twice in hdr_brackets.py and once in blender_merge.py), forming a source of potential bugs if someone ever
decides to change the output name (and forget to do that in both other places).

The combo (out_folder, i) is now also no longer passed to Blender; the final EXR file path is passed instead.

## Second

The `out_folder` variable is now the `Merged` folder. Appending the `jpg` and `exr` folders is now done in the same place, making them more 'equal' and avoiding the 'two steps forward, one step back' approach.

Old behaviour:
- Construct `.../Merged/exr`
- Take the parent, and append `jpg`

New behaviour:
- Construct `.../Merged`
- Append `exr` and `jpg`

For me personally I'm going to not use the 'exr' and 'jpg' directories at all, and just put the files directly into `Merged`. These changes make that easier.
